### PR TITLE
Disable maven-deploy-plugin

### DIFF
--- a/p2composite.example.tycho/pom.xml
+++ b/p2composite.example.tycho/pom.xml
@@ -31,6 +31,18 @@
 	</repositories>
 
 	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>2.8.2</version>
+					<configuration>
+						<skip>true</skip>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 
 		<plugins>
 			<plugin>


### PR DESCRIPTION
Enables to use the 'deploy' phase for the bintray upload without
deploying other artifacts