### PR TITLE
Support "release versions" by using qualifiedVersion property

### DIFF
--- a/p2composite.example.site/bintray.ant
+++ b/p2composite.example.site/bintray.ant
@@ -13,7 +13,7 @@
 	-->
 
 	<property name="bintray.url" value="https://dl.bintray.com/${bintray.owner}/${bintray.repo}" />
-	<property name="bintray.package.version" value="${unqualifiedVersion}.${buildQualifier}" />
+	<property name="bintray.package.version" value="${qualifiedVersion}" />
 	<property name="bintray.releases.target.path" value="${bintray.releases.path}/${bintray.package.version}" />
 
 	<property name="main.composite.url" value="${bintray.url}/${bintray.composite.path}" />

--- a/p2composite.example.site/packaging-p2composite.ant
+++ b/p2composite.example.site/packaging-p2composite.ant
@@ -22,14 +22,14 @@
 	<!--
 		site.label						The name/title/label of the created composite site
 		unqualifiedVersion 				The version without any qualifier replacement
-		buildQualifier					The build qualifier
+		qualifiedVersion 				The version with qualifier if any
 		child.repository.path.prefix	The path prefix to access the actual p2 repo from the
 										child repo, e.g., if child repo is in /updates/1.0 and
 										the p2 repo is in /releases/1.0.0.something then this property
 										should be "../../releases/"
 	-->
 	<target name="compute.child.repository.data" depends="getMajorMinorVersion">
-		<property name="full.version" value="${unqualifiedVersion}.${buildQualifier}" />
+		<property name="full.version" value="${qualifiedVersion}" />
 
 		<property name="site.composite.name" value="${site.label} ${majorMinorVersion}" />
 		<property name="main.site.composite.name" value="${site.label} All Versions" />

--- a/p2composite.example.site/pom.xml
+++ b/p2composite.example.site/pom.xml
@@ -103,7 +103,7 @@
 						<configuration>
 							<!-- Update p2 composite metadata or create it -->
 							<!-- IMPORTANT: DO NOT split the arg line -->
-							<appArgLine>-application org.eclipse.ant.core.antRunner -buildfile packaging-p2composite.ant p2.composite.add -Dsite.label="${site.label}" -Dproject.build.directory=${project.build.directory} -DunqualifiedVersion=${unqualifiedVersion} -DbuildQualifier=${buildQualifier} -Dchild.repository.path.prefix="${child.repository.path.prefix}"</appArgLine>
+							<appArgLine>-application org.eclipse.ant.core.antRunner -buildfile packaging-p2composite.ant p2.composite.add -Dsite.label="${site.label}" -Dproject.build.directory=${project.build.directory} -DunqualifiedVersion=${unqualifiedVersion} -DqualifiedVersion=${qualifiedVersion} -Dchild.repository.path.prefix="${child.repository.path.prefix}"</appArgLine>
 							<repositories>
 								<repository>
 									<id>mars</id>


### PR DESCRIPTION
"buildQualifier" is empty in release versions like "1.2.0", so "${unqualifiedVersion}.${buildQualifier}" would end up with trailing dot.

fixes #5