### PR TITLE
Upload files located in sub-folders (fix #10)

### DIFF
--- a/p2composite.example.site/bintray.ant
+++ b/p2composite.example.site/bintray.ant
@@ -106,7 +106,7 @@
 	</target>
 
 	<target name="push-p2-repo-to-bintray">
-		<apply executable="curl" parallel="false" relative="true" addsourcefile="false">
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false" forwardslash="true">
 			<arg value="-XPUT" />
 			<targetfile />
 
@@ -122,7 +122,7 @@
 	</target>
 
 	<target name="push-p2-repo-zipped-to-bintray">
-		<apply executable="curl" parallel="false" relative="true" addsourcefile="false">
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false" forwardslash="true">
 			<arg value="-XPUT" />
 			<targetfile />
 
@@ -138,7 +138,7 @@
 	</target>
 
 	<target name="push-composite-to-bintray" depends="getMajorMinorVersion" >
-		<apply executable="curl" parallel="false" relative="true" addsourcefile="false">
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false" forwardslash="true">
 			<arg value="-XPUT" />
 			<targetfile />
 
@@ -154,7 +154,7 @@
 	</target>
 
 	<target name="push-main-composite-to-bintray" >
-		<apply executable="curl" parallel="false" relative="true" addsourcefile="false">
+		<apply executable="curl" parallel="false" relative="true" addsourcefile="false" forwardslash="true">
 			<arg value="-XPUT" />
 			<targetfile />
 


### PR DESCRIPTION
As discussed in issue #10, here is a PR to fix the bug.

Note that although the `forwardslash` tag seems to be needed by the `push-p2-repo-to-bintray` target only, I also specified it for the other targets because it may prevent future problems.