### PR TITLE
Fix blog post link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ An example of how to create an Eclipse p2 Composite update site during the build
 
 This is described in this post:
 
-http://www.lorenzobettini.it/2016/02/publish-an-eclipse-p2-composite-repository-on-bintray/
+http://www.lorenzobettini.it/publish-an-eclipse-p2-composite-repository-on-bintray/


### PR DESCRIPTION
It seems that the URL of the blog post has changed, thus breaking the one specified in the README.

This commit fixes the link.